### PR TITLE
fix: assume insertText if event.inputType is unsupported

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,5 +24,5 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npm run build --if-present
+    - run: npm run build:plugin --if-present
     - run: npm test

--- a/src/core.js
+++ b/src/core.js
@@ -95,8 +95,11 @@ export function updateCursor(event, originalValue, originalPosition) {
     return
   }
 
+  // if event.inputType is not supported, assume 'insertText'
+  const inputType = event.inputType || 'insertText'
+
   // get some information about the cursor based on the original value
-  const isInsertEvent = ['insertText', 'insertFromPaste'].includes(event.inputType)
+  const isInsertEvent = ['insertText', 'insertFromPaste'].includes(inputType)
   const wasCursorAtEnd = isInsertEvent && originalPosition == originalValue.length
   let lastInsertedChar = isInsertEvent && originalValue[originalPosition - 1]
 

--- a/tests/directive.test.js
+++ b/tests/directive.test.js
@@ -135,7 +135,7 @@ describe('Directive', () => {
     })
   })
 
-  describe('Cursor updates', () => {
+  describe.each([['insertText'], [undefined]])('Cursor updates (inputType = %s)', (inputType) => {
     let element
 
     beforeEach(() => {
@@ -154,7 +154,18 @@ describe('Directive', () => {
       const newCursorPos = cursorPos + 1 // one new char inserted before
 
       element.selectionEnd = cursorPos
-      wrapper.find('input').trigger('input', { inputType: 'insertText' })
+      wrapper.find('input').trigger('input', { inputType })
+
+      expect(wrapper.element.setSelectionRange).toBeCalledWith(newCursorPos, newCursorPos)
+    })
+
+    test('Should stay next to the char just inserted', () => {
+      element.value = 'ABC1|23'
+      const cursorPos = element.value.indexOf('|')
+      const newCursorPos = cursorPos + 1 // one new char inserted before
+
+      element.selectionEnd = cursorPos
+      wrapper.find('input').trigger('input', { inputType })
 
       expect(wrapper.element.setSelectionRange).toBeCalledWith(newCursorPos, newCursorPos)
     })
@@ -165,7 +176,7 @@ describe('Directive', () => {
       const newCursorPos = cursorPos + 2 // two new characters after masking
 
       element.selectionEnd = cursorPos
-      wrapper.find('input').trigger('input', { inputType: 'insertText' })
+      wrapper.find('input').trigger('input', { inputType })
 
       expect(wrapper.element.setSelectionRange).toBeCalledWith(newCursorPos, newCursorPos)
     })
@@ -176,7 +187,7 @@ describe('Directive', () => {
       const newCursorPos = cursorPos - 1 // needs to move back as 'j' is not an allowed char
 
       element.selectionEnd = cursorPos
-      wrapper.find('input').trigger('input', { inputType: 'insertText' })
+      wrapper.find('input').trigger('input', { inputType })
 
       expect(wrapper.element.setSelectionRange).toBeCalledWith(newCursorPos, newCursorPos)
     })
@@ -189,7 +200,7 @@ describe('Directive', () => {
       element.value = 'ABC-1J|2'
       const cursorPos = element.value.indexOf('|')
       element.selectionEnd = cursorPos
-      wrapper.find('input').trigger('input', { inputType: 'insertText' })
+      wrapper.find('input').trigger('input', { inputType })
       expect(wrapper.element.setSelectionRange).not.toBeCalled()
     })
   })


### PR DESCRIPTION
Not all browsers support `InputEvent.inputType` ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/InputEvent/inputType#browser_compatibility)). This change assumes the `inputType` is `'insertText'` in cases where the event property is not available. This fixes problems with updating cursor position in IE11, and does not have any detrimental effects as far as I can tell.

I tweaked the existing cursor tests to also check behavior when `event.inputType` is not defined.